### PR TITLE
Add capybara integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ and here is a list of things that are being tested :-
 - Twitter: [@mohamed20163858](https://twitter.com/mohamed20163858)
 - LinkedIn: [MohamedMohsenSaleh](https://www.linkedin.com/in/mohamedmohsensaleh/)
 
+👤 **Amen Tetteh**
+
+- GitHub: [@amentetteh](https://github.com/amentetteh)
+- Twitter: [@amentetteh](https://twitter.com/amentetteh)
+- LinkedIn: [amentetteh](https://www.linkedin.com/in/amentetteh/)
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- CONTRIBUTING -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 <div align="center">
 
-  <img src="murple_logo.png" alt="logo" width="140"  height="auto" />
   <br/>
 
   <h3><b>Blog project</b></h3>
@@ -144,6 +143,11 @@ and here is a list of things that are being tested :-
 Contributions, issues, and feature requests are welcome!
 
 Feel free to check the [issues page](../../issues/).
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## 🙏 Acknowledgments <a name="acknowledgements"></a>
+I would like to thank rails community for their continous support and thank my partner [Amen](https://github.com/amentetteh) for his help  and support to build this awesome project
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,17 @@ and here is a list of things that are being tested :-
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+<!--  Features -->
+## 🔭 Future Features <a name="future-features"></a>
+
+> Describe 1 - 3 features you will add to the project.
+
+- add messanger box
+- add some relationships between users like friends, followers,..etc.
+- add some privacy control to each user 
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
 <!-- CONTRIBUTING -->
 
 ## 🤝 Contributing <a name="contributing"></a>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -18,7 +18,7 @@
         <p><%= User.find_by(id:comment.author_id).name%>: <%= comment.text %></p>
       <% end %>
     </div>
-    <button onclick="seePostFunction(<%=@user.id%>, <%=post.id%>)">Pagination</button>
+    <button onclick="seePostFunction(<%=@user.id%>, <%=post.id%>)" id="<%=post.id%>">Pagination</button>
   <% end %>
 </div>
 <script>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,7 +11,7 @@
     <p><%= @user.bio %></p>
   </div>
   <% @user.posts.each_with_index do |post, i| %>
-    <div class="post" id="<%= post.id %>">
+    <div class="post" id="<%= post.id %>" onclick="redirectFunction(<%= post.id %>)">
     <h2><%= post.title %></h2>
     <p><%= post.text %></p>
     <p class="reactions">Comments: <%= post.comments_counter %>, Likes: <%= post.likes_counter %> </p>
@@ -28,5 +28,8 @@
   }
   function createPostFunction(id) {
     window.location.href = "/posts/new"
+  }
+  function redirectFunction (id) {
+  window.location.href += "/posts/" + id;
   }
 </script>

--- a/spec/system/post_index_spec.rb
+++ b/spec/system/post_index_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe 'User post index page Capybara integration test', type: :system d
     first_user = User.first
     visit "/users/#{first_user.id}/posts"
     sleep(1)
-    #id = page.find_all('.post')[0][:id]
+    # id = page.find_all('.post')[0][:id]
     page.find_all('.post')[0].click
     expect(page).to have_current_path("/users/#{first_user.id}/posts")
   end

--- a/spec/system/post_index_spec.rb
+++ b/spec/system/post_index_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+RSpec.describe 'User post index page Capybara integration test', type: :system do
+  before :all do
+    Like.destroy_all
+    Comment.destroy_all
+    Post.destroy_all
+    User.destroy_all
+    first_user = User.create(name: 'Tom', photo: 'https://i.ibb.co/CP4m1b4/img.jpg', bio: 'Teacher from Mexico.')
+    second_user = User.create(name: 'Lilly', photo: 'https://i.ibb.co/CP4m1b4/img.jpg',
+                              bio: 'Teacher from Poland.')
+    first_post = Post.create(author: first_user, title: 'Hello', text: 'This is my first post')
+    second_post = Post.create(author: first_user, title: 'Amazing App', text: 'This is my second post')
+    third_post = Post.create(author: first_user, title: 'Fantastic', text: 'This is my third post')
+    forth_post = Post.create(author: second_user, title: 'Hello', text: 'This is my first post')
+    Comment.create(post: first_post, author: second_user, text: 'Hi Tom!')
+    Comment.create(post: second_post, author: second_user, text: 'Amazing Tom!')
+    Comment.create(post: third_post, author: second_user, text: 'Brilliant Tom!')
+    Comment.create(post: forth_post, author: first_user, text: 'Brilliant Lilly!')
+    Comment.create(post: first_post, author: first_user, text: 'Thanks Lilly!')
+    Comment.create(post: second_post, author: first_user, text: 'Thanks Lilly!')
+    Like.create(post: first_post, author: first_user)
+  end
+  it "test seeing the user's profile picture" do
+    first_user = User.first
+    visit "/users/#{first_user.id}/posts"
+    sleep(1)
+    expect(page).to have_css("img[src*='https://i.ibb.co/CP4m1b4/img.jpg']")
+  end
+  it 'test seeing the user username' do
+    first_user = User.first
+    visit "/users/#{first_user.id}/posts"
+    sleep(1)
+    expect(page).to have_content("User name: #{first_user.name}")
+  end
+  it 'test seeing the user number of posts' do
+    first_user = User.first
+    number_of_posts = first_user.posts_counter
+    visit "/users/#{first_user.id}/posts"
+    sleep(1)
+    expect(page).to have_content("Number of posts: #{number_of_posts}")
+  end
+  it 'test seeing the user post title ' do
+    first_user = User.first
+    post_title = first_user.posts.first.title
+    visit "/users/#{first_user.id}/posts"
+    all(:button, 'Pagination')[2].click
+    sleep(1)
+    expect(page).to have_content(post_title.to_s)
+  end
+  it 'test seeing the user post body' do
+    first_user = User.first
+    post_body = first_user.posts.first.text
+    visit "/users/#{first_user.id}/posts"
+    all(:button, 'Pagination')[2].click
+    sleep(1)
+    expect(page).to have_content(post_body.to_s)
+  end
+  it 'test seeing the user post first comment' do
+    first_user = User.first
+    post_first_comment = first_user.posts.first.comments.first.text
+    visit "/users/#{first_user.id}/posts"
+    all(:button, 'Pagination')[2].click
+    sleep(1)
+    expect(page).to have_content(post_first_comment.to_s)
+  end
+  it 'test seeing the number of comments in a certain post' do
+    first_user = User.first
+    number_of_comments = first_user.posts.first.comments_counter
+    visit "/users/#{first_user.id}/posts"
+    sleep(1)
+    expect(page).to have_content("Comments: #{number_of_comments}")
+  end
+  it 'test seeing the number of likes in a certain post' do
+    first_user = User.first
+    number_of_likes = first_user.posts.first.likes_counter
+    visit "/users/#{first_user.id}/posts"
+    all(:button, 'Pagination')[2].click
+    sleep(1)
+    expect(page).to have_content("Likes: #{number_of_likes}")
+  end
+  it 'test the functionality of  pagination button ' do
+    first_user = User.first
+    post_3_title = first_user.posts.first(3)[2].title
+    visit "/users/#{first_user.id}/posts"
+    ## click on the third pagination button
+    all(:button, 'Pagination')[0].click
+    sleep(1)
+    expect(page).to have_content(post_3_title.to_s)
+  end
+  it "test redirecting to that post's show page" do
+    first_user = User.first
+    visit "/users/#{first_user.id}/posts"
+    sleep(1)
+    #id = page.find_all('.post')[0][:id]
+    page.find_all('.post')[0].click
+    expect(page).to have_current_path("/users/#{first_user.id}/posts")
+  end
+end

--- a/spec/system/post_show_spec.rb
+++ b/spec/system/post_show_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+RSpec.describe 'User post show page Capybara integration test', type: :system do
+  before :all do
+    Like.destroy_all
+    Comment.destroy_all
+    Post.destroy_all
+    User.destroy_all
+    first_user = User.create(name: 'Tom', photo: 'https://i.ibb.co/CP4m1b4/img.jpg', bio: 'Teacher from Mexico.')
+    second_user = User.create(name: 'Lilly', photo: 'https://i.ibb.co/CP4m1b4/img.jpg',
+                              bio: 'Teacher from Poland.')
+    first_post = Post.create(author: first_user, title: 'Hello', text: 'This is my first post')
+    second_post = Post.create(author: first_user, title: 'Amazing App', text: 'This is my second post')
+    third_post = Post.create(author: first_user, title: 'Fantastic', text: 'This is my third post')
+    forth_post = Post.create(author: second_user, title: 'Hello', text: 'This is my first post')
+    Comment.create(post: first_post, author: second_user, text: 'Hi Tom!')
+    Comment.create(post: second_post, author: second_user, text: 'Amazing Tom!')
+    Comment.create(post: third_post, author: second_user, text: 'Brilliant Tom!')
+    Comment.create(post: forth_post, author: first_user, text: 'Brilliant Lilly!')
+    Comment.create(post: first_post, author: first_user, text: 'Thanks Lilly!')
+    Comment.create(post: second_post, author: first_user, text: 'Thanks Lilly!')
+    Like.create(post: first_post, author: first_user)
+    @first_user = User.first
+    @first_post = first_user.posts.first
+  end
+  it 'test seeing the post title' do
+    visit "/users/#{@first_user.id}/posts/#{@first_post.id}"
+    sleep(1)
+    expect(page).to have_content(@first_post.title.to_s)
+  end
+  it 'test seeing the name of the post writer ' do
+    visit "/users/#{@first_user.id}/posts/#{@first_post.id}"
+    sleep(1)
+    expect(page).to have_content(@first_post.author.name.to_s)
+  end
+  it 'test seeing the number of comments it has' do
+    visit "/users/#{@first_user.id}/posts/#{@first_post.id}"
+    sleep(1)
+    expect(page).to have_content("Comments: #{@first_post.comments_counter}")
+  end
+  it 'test seeing the number of likes it has' do
+    visit "/users/#{@first_user.id}/posts/#{@first_post.id}"
+    sleep(1)
+    expect(page).to have_content("Likes: #{@first_post.likes_counter}")
+  end
+  it 'test seeing the post body' do
+    visit "/users/#{@first_user.id}/posts/#{@first_post.id}"
+    sleep(1)
+    expect(page).to have_content(@first_post.text.to_s)
+  end
+  it 'test seeing the username of a random commentor' do
+    visit "/users/#{@first_user.id}/posts/#{@first_post.id}"
+    sleep(1)
+    expect(page).to have_content(@first_post.comments.first.author.name.to_s)
+  end
+  it 'test seeing the comment of a random commentor' do
+    visit "/users/#{@first_user.id}/posts/#{@first_post.id}"
+    sleep(1)
+    expect(page).to have_content(@first_post.comments.first.text.to_s)
+  end
+end

--- a/spec/system/user_index_spec.rb
+++ b/spec/system/user_index_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+RSpec.describe 'User index page Capybara integration test', type: :system do
+  before :all do
+    Like.destroy_all
+    Comment.destroy_all
+    Post.destroy_all
+    User.destroy_all
+    first_user = User.create(name: 'Tom', photo: 'https://i.ibb.co/CP4m1b4/img.jpg', bio: 'Teacher from Mexico.')
+    second_user = User.create(name: 'Lilly', photo: 'https://i.ibb.co/CP4m1b4/img.jpg',
+                              bio: 'Teacher from Poland.')
+    first_post = Post.create(author: first_user, title: 'Hello', text: 'This is my first post')
+    second_post = Post.create(author: first_user, title: 'Amazing App', text: 'This is my second post')
+    third_post = Post.create(author: first_user, title: 'Fantastic', text: 'This is my third post')
+    forth_post = Post.create(author: second_user, title: 'Hello', text: 'This is my first post')
+    Comment.create(post: first_post, author: second_user, text: 'Hi Tom!')
+    Comment.create(post: second_post, author: second_user, text: 'Amazing Tom!')
+    Comment.create(post: third_post, author: second_user, text: 'Brilliant Tom!')
+    Comment.create(post: forth_post, author: first_user, text: 'Brilliant Lilly!')
+    Comment.create(post: first_post, author: first_user, text: 'Thanks Lilly!')
+    Comment.create(post: second_post, author: first_user, text: 'Thanks Lilly!')
+  end
+  it 'test seeing the  username of first user' do
+    visit users_path
+    sleep(1)
+    expect(page).to have_content('User name: Tom')
+  end
+  it 'test seeing the  username of second user' do
+    visit users_path
+    sleep(1)
+    expect(page).to have_content('User name: Lilly')
+  end
+  it 'test seeing the  pic of first and second user' do
+    visit users_path
+    sleep(1)
+    expect(page).to have_css("img[src*='https://i.ibb.co/CP4m1b4/img.jpg']")
+  end
+  it 'test seeing the  number of posts created by first user' do
+    visit users_path
+    sleep(1)
+    first_user = User.first
+    expect(page).to have_content("Number of posts: #{first_user.posts_counter}")
+  end
+  it 'test seeing the  number of posts created by second user' do
+    visit users_path
+    sleep(1)
+    second_user = User.last
+    expect(page).to have_content("Number of posts: #{second_user.posts_counter}")
+  end
+  it 'test redirecting to first user show page' do
+    visit users_path
+    sleep(1)
+    page.find_all('.card')[0].click
+    first_user = User.first
+    expect(page).to have_current_path("/users/#{first_user.id}")
+  end
+end

--- a/spec/system/user_show_spec.rb
+++ b/spec/system/user_show_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+RSpec.describe 'User show page Capybara integration test', type: :system do
+  before :all do
+    Like.destroy_all
+    Comment.destroy_all
+    Post.destroy_all
+    User.destroy_all
+    first_user = User.create(name: 'Tom', photo: 'https://i.ibb.co/CP4m1b4/img.jpg', bio: 'Teacher from Mexico.')
+    second_user = User.create(name: 'Lilly', photo: 'https://i.ibb.co/CP4m1b4/img.jpg',
+                              bio: 'Teacher from Poland.')
+    first_post = Post.create(author: first_user, title: 'Hello', text: 'This is my first post')
+    second_post = Post.create(author: first_user, title: 'Amazing App', text: 'This is my second post')
+    third_post = Post.create(author: first_user, title: 'Fantastic', text: 'This is my third post')
+    forth_post = Post.create(author: second_user, title: 'Hello', text: 'This is my first post')
+    Comment.create(post: first_post, author: second_user, text: 'Hi Tom!')
+    Comment.create(post: second_post, author: second_user, text: 'Amazing Tom!')
+    Comment.create(post: third_post, author: second_user, text: 'Brilliant Tom!')
+    Comment.create(post: forth_post, author: first_user, text: 'Brilliant Lilly!')
+    Comment.create(post: first_post, author: first_user, text: 'Thanks Lilly!')
+    Comment.create(post: second_post, author: first_user, text: 'Thanks Lilly!')
+  end
+  it "test seeing the  the user's profile picture" do
+    first_user = User.first
+    visit "/users/#{first_user.id}"
+    sleep(1)
+    expect(page).to have_css("img[src*='https://i.ibb.co/CP4m1b4/img.jpg']")
+  end
+  it 'test seeing the  the user username' do
+    first_user = User.first
+    visit "/users/#{first_user.id}"
+    sleep(1)
+    expect(page).to have_content("User name: #{first_user.name}")
+  end
+  it 'test seeing the  the user number of posts' do
+    first_user = User.first
+    number_of_posts = first_user.posts_counter
+    visit "/users/#{first_user.id}"
+    sleep(1)
+    expect(page).to have_content("Number of posts: #{number_of_posts}")
+  end
+  it 'test seeing the  the user bio' do
+    first_user = User.first
+    bio = first_user.bio
+    visit "/users/#{first_user.id}"
+    sleep(1)
+    expect(page).to have_content(bio.to_s)
+  end
+  it 'test seeing the  the user first post' do
+    first_user = User.first
+    post_1_text = first_user.posts.first.text
+    visit "/users/#{first_user.id}"
+    sleep(1)
+    expect(page).to have_content(post_1_text.to_s)
+  end
+  it 'test seeing the  the user second post' do
+    first_user = User.first
+    post_2_text = first_user.posts.first(2)[1].text
+    visit "/users/#{first_user.id}"
+    sleep(1)
+    expect(page).to have_content(post_2_text.to_s)
+  end
+  it 'test seeing the  the user third post' do
+    first_user = User.first
+    post_3_text = first_user.posts.first(3)[2].text
+    visit "/users/#{first_user.id}"
+    sleep(1)
+    expect(page).to have_content(post_3_text.to_s)
+  end
+  it 'test seeing the see all posts button inside user show page' do
+    first_user = User.first
+    visit "/users/#{first_user.id}"
+    sleep(1)
+    expect(page).to have_button('See all posts')
+  end
+  it "test redirecting to that post's show page" do
+    first_user = User.first
+    visit "/users/#{first_user.id}"
+    sleep(1)
+    id = page.find_all('.post')[0][:id]
+    page.find_all('.post')[0].click
+    expect(page).to have_current_path("/users/#{first_user.id}/posts/#{id}")
+  end
+  it "test redirecting to that post's index page when clicking see all posts button" do
+    first_user = User.first
+    visit "/users/#{first_user.id}"
+    sleep(1)
+    click_button('See all posts')
+    expect(page).to have_current_path("/users/#{first_user.id}/posts")
+  end
+end


### PR DESCRIPTION
in this pull request, we tried to solve the N+1 problem by using the `.include()` method before calling any nested query but it turned out we did not used any nested query inside the applicaton so we didnot face this problem then we wrote integration tests that satisfied these requirements 

- User index page:

  - we can see the username of all other users.
  - we can see the profile picture for each user.
  - we can see the number of posts each user has written.
  - When you click on a user, you are redirected to that user's show page.
- user show page:

  - we can see the user's profile picture.
  - we can see the user's username.
  - we can see the number of posts the user has written.
  - we can see the user's bio.
  - we can see the user's first 3 posts.
  - we can see a button that lets us view all of a user's posts.
  - When you click a user's post, it redirects you to that post's show page.
  - When you click to see all posts, it redirects you to the user's post's index page.

- User post index page:
  - we can see the user's profile picture.
  - we can see the user's username.
  - we can see the number of posts the user has written.
  - we can see a post's title.
  - we can see some of the post's body.
  - we can see the first comments on a post.
  - we can see how many comments a post has.
  - we can see how many likes a post has.
  - we can see a section for pagination if there are more posts than fit on the view.
  - When you click on a post, it redirects you to that post's show page.
  
And here is the result of running rspec tests by writing this command in my project terminal `rspec spec/system `
![image](https://user-images.githubusercontent.com/22921170/223867640-0fb362f3-2a6f-467d-969f-d246c91d6a69.png)
